### PR TITLE
Fix: Multiple merchants and profile switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,24 @@ Three permanent async tasks:
 - NIP-04 encryption/decryption
 - Key derivation and bech32 encoding (npub/nsec)
 
+## Testing with LNbits
+
+To test the extension locally with LNbits:
+
+```bash
+# Create symlink in LNbits extensions directory (if not already done)
+mkdir -p /path/to/lnbits/lnbits/extensions
+ln -sf /path/to/nostrmarket /path/to/lnbits/lnbits/extensions/nostrmarket
+
+# Start LNbits (from lnbits directory, keep terminal open)
+cd /path/to/lnbits
+uv run lnbits --port 5001
+```
+
+Access at http://localhost:5001 and enable the extension in Admin > Extensions.
+
+Note: The nostrclient extension must also be installed and configured for full functionality.
+
 ## Workflow
 
 - Always check GitHub Actions after pushing to verify CI passes

--- a/crud.py
+++ b/crud.py
@@ -95,12 +95,46 @@ async def get_merchants_ids_with_pubkeys() -> list[tuple[str, str]]:
 
 
 async def get_merchant_for_user(user_id: str) -> Merchant | None:
+    # First try to get the selected merchant
     row: dict = await db.fetchone(
-        """SELECT * FROM nostrmarket.merchants WHERE user_id = :user_id """,
+        """SELECT * FROM nostrmarket.merchants
+           WHERE user_id = :user_id AND selected = true""",
+        {"user_id": user_id},
+    )
+    # If no selected merchant, get the most recently touched one
+    if not row:
+        row = await db.fetchone(
+            """SELECT * FROM nostrmarket.merchants WHERE user_id = :user_id
+               ORDER BY time DESC""",
+            {"user_id": user_id},
+        )
+
+    return Merchant.from_row(row) if row else None
+
+
+async def get_merchants_for_user(user_id: str) -> list[Merchant]:
+    rows: list[dict] = await db.fetchall(
+        """SELECT * FROM nostrmarket.merchants WHERE user_id = :user_id
+           ORDER BY selected DESC, time DESC""",
         {"user_id": user_id},
     )
 
-    return Merchant.from_row(row) if row else None
+    return [Merchant.from_row(row) for row in rows]
+
+
+async def set_merchant_selected(user_id: str, merchant_id: str) -> None:
+    # First, deselect all merchants for this user
+    await db.execute(
+        """UPDATE nostrmarket.merchants SET selected = false
+           WHERE user_id = :user_id""",
+        {"user_id": user_id},
+    )
+    # Then select the specified merchant
+    await db.execute(
+        """UPDATE nostrmarket.merchants SET selected = true
+           WHERE user_id = :user_id AND id = :merchant_id""",
+        {"user_id": user_id, "merchant_id": merchant_id},
+    )
 
 
 async def delete_merchant(merchant_id: str) -> None:

--- a/migrations.py
+++ b/migrations.py
@@ -189,3 +189,12 @@ async def m005_update_product_activation(db):
         ADD COLUMN active BOOLEAN NOT NULL DEFAULT true;
         """
     )
+
+
+async def m006_add_merchant_selected_flag(db):
+    await db.execute(
+        """
+        ALTER TABLE nostrmarket.merchants
+        ADD COLUMN selected BOOLEAN NOT NULL DEFAULT false;
+        """
+    )

--- a/models.py
+++ b/models.py
@@ -58,6 +58,7 @@ class PartialMerchant(BaseModel):
 class Merchant(PartialMerchant, Nostrable):
     id: str
     time: int | None = 0
+    selected: bool = False
 
     def sign_hash(self, hash_: bytes) -> str:
         return sign_message_hash(self.private_key, hash_)

--- a/static/components/merchant-tab.js
+++ b/static/components/merchant-tab.js
@@ -11,7 +11,8 @@ window.app.component('merchant-tab', {
     'public-key',
     'private-key',
     'is-admin',
-    'merchant-config'
+    'merchant-config',
+    'merchants'
   ],
   emits: [
     'toggle-show-keys',
@@ -21,7 +22,8 @@ window.app.component('merchant-tab', {
     'restart-nostr-connection',
     'profile-updated',
     'import-key',
-    'generate-key'
+    'generate-key',
+    'switch-merchant'
   ],
   data: function () {
     return {
@@ -93,6 +95,14 @@ window.app.component('merchant-tab', {
     },
     handleImageError: function (e) {
       e.target.style.display = 'none'
+    },
+    switchMerchant: function (merchantId) {
+      this.$emit('switch-merchant', merchantId)
+    },
+    getMerchantDisplayName: function (merchant) {
+      if (merchant.config?.display_name) return merchant.config.display_name
+      if (merchant.config?.name) return merchant.config.name
+      return merchant.public_key?.slice(0, 8) + '...'
     }
   }
 })

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -8,6 +8,7 @@ window.app = Vue.createApp({
       activeTab: 'orders',
       selectedStallFilter: null,
       merchant: {},
+      merchants: [],
       shippingZones: [],
       activeChatCustomer: '',
       orderPubkey: null,
@@ -158,6 +159,7 @@ window.app = Vue.createApp({
           payload
         )
         this.merchant = data
+        await this.getMerchants()
         this.$q.notify({
           type: 'positive',
           message: 'Merchant Created!'
@@ -176,6 +178,37 @@ window.app = Vue.createApp({
         )
         this.merchant = data
         return data
+      } catch (error) {
+        LNbits.utils.notifyApiError(error)
+      }
+    },
+    getMerchants: async function () {
+      try {
+        const {data} = await LNbits.api.request(
+          'GET',
+          '/nostrmarket/api/v1/merchants',
+          this.g.user.wallets[0].inkey
+        )
+        this.merchants = data || []
+        return data
+      } catch (error) {
+        LNbits.utils.notifyApiError(error)
+      }
+    },
+    switchMerchant: async function (merchantId) {
+      try {
+        const {data} = await LNbits.api.request(
+          'PUT',
+          `/nostrmarket/api/v1/merchant/${merchantId}/switch`,
+          this.g.user.wallets[0].adminkey
+        )
+        this.merchant = data
+        await this.getMerchants()
+        this.waitForNotifications()
+        this.$q.notify({
+          type: 'positive',
+          message: 'Switched merchant profile'
+        })
       } catch (error) {
         LNbits.utils.notifyApiError(error)
       }
@@ -410,6 +443,7 @@ window.app = Vue.createApp({
   },
   created: async function () {
     await this.getMerchant()
+    await this.getMerchants()
     await this.checkNostrStatus()
     setInterval(async () => {
       if (

--- a/templates/nostrmarket/components/merchant-tab.html
+++ b/templates/nostrmarket/components/merchant-tab.html
@@ -1,6 +1,6 @@
 <div>
   <div class="row q-col-gutter-md">
-    <div class="col-12 col-md-8">
+    <div class="col-12">
       <q-card v-if="publicKey" flat bordered>
         <q-card-section>
           <div class="row items-center no-wrap q-mb-md">
@@ -33,27 +33,34 @@
             >
               <q-list>
                 <q-item-label header>Saved Profiles</q-item-label>
-                <q-item>
+                <q-item
+                  v-for="m in merchants"
+                  :key="m.id"
+                  clickable
+                  v-close-popup
+                  @click="m.id !== merchantId && switchMerchant(m.id)"
+                >
                   <q-item-section avatar>
-                    <q-icon name="check" color="primary"></q-icon>
+                    <q-icon
+                      :name="m.id === merchantId ? 'check' : 'person'"
+                      :color="m.id === merchantId ? 'primary' : 'grey'"
+                    ></q-icon>
                   </q-item-section>
                   <q-item-section>
-                    <q-item-label
-                      ><span
-                        v-text="merchantConfig?.display_name || merchantConfig?.name || 'Current Profile'"
-                      ></span
-                    ></q-item-label>
+                    <q-item-label>
+                      <span v-text="getMerchantDisplayName(m)"></span>
+                    </q-item-label>
                     <q-item-label
                       caption
                       class="text-mono"
                       style="font-size: 10px"
                     >
                       <span
-                        v-text="publicKey ? publicKey.slice(0, 16) + '...' : ''"
+                        v-text="m.public_key ? m.public_key.slice(0, 16) + '...' : ''"
                       ></span>
                     </q-item-label>
                   </q-item-section>
-                  <q-item-section side>
+                  <q-item-section side v-if="m.id === merchantId">
                     <q-btn
                       flat
                       dense

--- a/templates/nostrmarket/components/merchant-tab.html
+++ b/templates/nostrmarket/components/merchant-tab.html
@@ -174,7 +174,7 @@
           <div class="row">
             <!-- Profile Image -->
             <div class="col-auto">
-              <q-avatar size="100px" color="dark" class="profile-avatar">
+              <q-avatar size="100px" color="grey-8" class="profile-avatar">
                 <img
                   v-if="merchantConfig && merchantConfig.picture"
                   :src="merchantConfig.picture"
@@ -185,7 +185,7 @@
                   v-else
                   name="person"
                   size="60px"
-                  color="grey-5"
+                  color="grey-4"
                 ></q-icon>
               </q-avatar>
             </div>

--- a/templates/nostrmarket/index.html
+++ b/templates/nostrmarket/index.html
@@ -77,6 +77,7 @@
               :private-key="merchant.private_key"
               :is-admin="g.user.admin"
               :merchant-config="merchant.config"
+              :merchants="merchants"
               @toggle-show-keys="toggleShowKeys"
               @hide-keys="showKeys = false"
               @merchant-deleted="handleMerchantDeleted"
@@ -85,6 +86,7 @@
               @import-key="showImportKeysDialog"
               @generate-key="generateKeys"
               @profile-updated="getMerchant"
+              @switch-merchant="switchMerchant"
             ></merchant-tab>
           </q-tab-panel>
 

--- a/views_api.py
+++ b/views_api.py
@@ -36,6 +36,8 @@ from .crud import (
     get_last_direct_messages_time,
     get_merchant_by_pubkey,
     get_merchant_for_user,
+    get_merchants_for_user,
+    set_merchant_selected,
     get_order,
     get_order_by_event_id,
     get_orders,
@@ -100,6 +102,10 @@ async def api_create_merchant(
 
         merchant = await create_merchant(wallet.wallet.user, data)
 
+        # Select the newly created merchant
+        await set_merchant_selected(wallet.wallet.user, merchant.id)
+        merchant.selected = True
+
         await create_zone(
             merchant.id,
             Zone(
@@ -151,6 +157,52 @@ async def api_get_merchant(
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail="Cannot get merchant",
+        ) from ex
+
+
+@nostrmarket_ext.get("/api/v1/merchants")
+async def api_get_merchants(
+    wallet: WalletTypeInfo = Depends(require_invoice_key),
+) -> list[Merchant]:
+
+    try:
+        merchants = await get_merchants_for_user(wallet.wallet.user)
+        return merchants
+    except Exception as ex:
+        logger.warning(ex)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Cannot get merchants",
+        ) from ex
+
+
+@nostrmarket_ext.put("/api/v1/merchant/{merchant_id}/switch")
+async def api_switch_merchant(
+    merchant_id: str,
+    wallet: WalletTypeInfo = Depends(require_admin_key),
+) -> Merchant:
+    try:
+        merchants = await get_merchants_for_user(wallet.wallet.user)
+        merchant_ids = [m.id for m in merchants]
+        assert merchant_id in merchant_ids, "Merchant not found for this user"
+
+        await set_merchant_selected(wallet.wallet.user, merchant_id)
+        merchant = await touch_merchant(wallet.wallet.user, merchant_id)
+        assert merchant, "Merchant cannot be found"
+
+        await resubscribe_to_all_merchants()
+
+        return merchant
+    except AssertionError as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=str(ex),
+        ) from ex
+    except Exception as ex:
+        logger.warning(ex)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Cannot switch merchant",
         ) from ex
 
 


### PR DESCRIPTION
## Summary
- Add support for multiple merchants per user with profile switching
- New `GET /api/v1/merchants` endpoint to list all merchants for a user
- New `PUT /api/v1/merchant/{id}/switch` endpoint to switch active merchant
- Added `selected` boolean column to merchants table (migration m006)
- Updated frontend with merchant dropdown selector in the merchant tab
- Fixed profile avatar visibility in dark mode (changed from transparent to grey)

## Test plan
- [ ] Create multiple merchants by adding different nsecs
- [ ] Verify all merchants appear in the dropdown selector
- [ ] Switch between merchants and confirm products/stalls load correctly
- [ ] Test in dark mode to verify avatar visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)